### PR TITLE
Public

### DIFF
--- a/src/com/js/interpreter/ast/FunctionDeclaration.java
+++ b/src/com/js/interpreter/ast/FunctionDeclaration.java
@@ -19,6 +19,7 @@ import com.js.interpreter.ast.instructions.conditional.WhileStatement;
 import com.js.interpreter.ast.instructions.returnsvalue.FunctionCall;
 import com.js.interpreter.ast.instructions.returnsvalue.ReturnsValue;
 import com.js.interpreter.exceptions.ExpectedTokenException;
+import com.js.interpreter.exceptions.OverridingException;
 import com.js.interpreter.exceptions.OverridingFunctionException;
 import com.js.interpreter.exceptions.ParsingException;
 import com.js.interpreter.exceptions.UnconvertableTypeException;
@@ -96,11 +97,22 @@ public class FunctionDeclaration extends AbstractFunction implements
 		}
 		i.assert_next_semicolon();
 		next = i.peek();
-		if (next instanceof VarToken) {
+		local_variables = new ArrayList<VariableDeclaration>();
+		while(next instanceof VarToken){
 			i.take();
-			local_variables = i.get_variable_declarations(this);
-		} else {
-			local_variables = new ArrayList<VariableDeclaration>();
+			List<VariableDeclaration> newvars = i.get_variable_declarations(this);
+			for(VariableDeclaration v : newvars){
+				//no nested functions yet
+				//for(AbstractFunction f : callable_functions.get(v.name)){
+				//	throw new OverridingFunctionWithVariableException(f,v,i.lineInfo);
+				//}
+				for(VariableDeclaration e : local_variables){
+					if(v.name.equals(e.name))
+						throw new OverridingException(e,v,i.lineInfo);
+				}
+			}
+			local_variables.addAll(newvars);
+			next = i.peek();
 		}
 		instructions = null;
 	}

--- a/src/com/js/interpreter/ast/codeunit/PascalProgram.java
+++ b/src/com/js/interpreter/ast/codeunit/PascalProgram.java
@@ -44,6 +44,8 @@ public class PascalProgram extends ExecutableCodeUnit {
 		main.argument_names = new String[0];
 		main.argument_types = new RuntimeType[0];
 		main.name = "main";
+		// we replace the UnitVarDefs with the reference to main.locals 
+		this.UnitVarDefs = main.local_variables;
 	}
 
 	@Override
@@ -62,12 +64,6 @@ public class PascalProgram extends ExecutableCodeUnit {
 	@Override
 	public RuntimeExecutable<PascalProgram> run() {
 		return new RuntimePascalProgram(this);
-	}
-
-	@Override
-	protected void handleGloablVarDeclaration(
-			List<VariableDeclaration> declarations) {
-		main.local_variables.addAll(declarations);
 	}
 
 	@Override

--- a/src/com/js/interpreter/exceptions/OverridingException.java
+++ b/src/com/js/interpreter/exceptions/OverridingException.java
@@ -1,0 +1,61 @@
+package com.js.interpreter.exceptions;
+
+import com.js.interpreter.ast.AbstractFunction;
+import com.js.interpreter.ast.VariableDeclaration;
+import com.js.interpreter.linenumber.LineInfo;
+
+public class OverridingException extends ParsingException {
+
+	public OverridingException(AbstractFunction f,
+			String constantName, LineInfo line) {
+		super(line, "Cannot define constant "+constantName+". There is already a function "+f.toString()
+				+ " which was previous defined with this name.");
+	}
+
+	public OverridingException(
+			String constantName, AbstractFunction f, LineInfo line) {
+		super(line, "Cannot define function "+f.toString()+". There is already a constant "+constantName
+				+ " which was previous defined with this name.");
+	}
+	
+	public OverridingException(
+			String constantName, VariableDeclaration v, LineInfo line) {
+		super(line, "Cannot define variable "+v.name+". There is already a constant "+constantName
+				+ " which was previous defined with this name.");
+	}
+	public OverridingException(
+			String constantName, String constantName2, LineInfo line) {
+		super(line, "Cannot define constant "+constantName+". There is already another constant "+constantName2
+				+ " which was previous defined.");
+	}
+
+	public OverridingException(VariableDeclaration v, AbstractFunction f,
+			LineInfo line) {
+		super(line, "Cannot define function "+f.toString()+". There is already a variable "+v.name
+				+ " which was previous defined.");
+	}
+
+	public OverridingException(VariableDeclaration v, String conststant,
+			LineInfo line) {
+		super(line, "Cannot define variable "+v.name+". There is already a constant "+conststant
+				+ " which was previous defined.");
+	}
+
+	public OverridingException(VariableDeclaration old, VariableDeclaration n, LineInfo line) {
+		super(line, "Cannot define variabele "+n.name+". There is already a variable " + old.name
+				+ " which was previous define at " + line.line);
+	}
+
+	public OverridingException(AbstractFunction v, VariableDeclaration f,
+			LineInfo line) {
+		super(line, "Cannot define variable "+f.name+". There is already a function "+v.toString()
+				+ " which was previous defined.");
+	}
+
+	public OverridingException(AbstractFunction v, AbstractFunction f,
+			LineInfo line) {
+		super(line, "Cannot define "+f.toString()+". There is already a function "+f.toString()
+				+ " which was previous defined.");
+	}
+
+}

--- a/src/com/js/interpreter/plugins/Math_plugins.java
+++ b/src/com/js/interpreter/plugins/Math_plugins.java
@@ -17,8 +17,19 @@ public class Math_plugins implements PascalPlugin {
 		return (int) Math.ceil(d);
 	}
 
+	public static int trunc(double d) {
+		return floor(d);
+	}
+	public static double frac(double d){
+		return d-floor(d);
+	}
+	
 	public static int floor(double d) {
 		return (int) Math.floor(d);
+	}
+
+	public static double abs(double d){
+		return Math.abs(d);
 	}
 
 	public static int round(double d) {

--- a/src/com/js/interpreter/plugins/Misc_plugins.java
+++ b/src/com/js/interpreter/plugins/Misc_plugins.java
@@ -26,6 +26,12 @@ public class Misc_plugins implements PascalPlugin {
 		a.set(result);
 	}
 
+	@MethodTypeData(info = { @ArrayBoundsInfo(starts = { 0 }, lengths = { 0 }),
+			@ArrayBoundsInfo })
+	public static void setLength(VariableBoxer<Object[]> a, int length) throws RuntimePascalException {
+		SetArrayLength(a,length);
+	}
+	
 	@MethodTypeData(info = { @ArrayBoundsInfo(starts = { 0 }, lengths = { 0 }) })
 	public static int length(Object[] o) {
 		return o.length;

--- a/src/com/js/interpreter/plugins/Misc_plugins.java
+++ b/src/com/js/interpreter/plugins/Misc_plugins.java
@@ -37,6 +37,10 @@ public class Misc_plugins implements PascalPlugin {
 		return o.length;
 	}
 
+	public static int length(StringBuilder s) {
+		return s.length();
+	}
+
 	@Override
 	public boolean instantiate(Map<String, Object> pluginargs) {
 		return true;


### PR DESCRIPTION
Hi Jeremy,

I have added some code to the project which might be worth integrating. First commit contains just a few plugin functions for math. The second commit is a larger change to CodeUnit to deal with override declarations.

The interpreter will now send a OverrideException when:
- same variable name used twice
- same const name used twice
- same function defined twice (you already did that)
- variable name used that is already a const name
- variable name used that is already a function name
- function name used that is already a const name
- function name used that is already a variable name
- const name used that is already a variable name
- const name used that is already a function name

This check is performed in a single function that might be used for nested functions later on as well. 
