### PR TITLE
Fix bug when use references type in function

### DIFF
--- a/src/com/js/interpreter/runtime/FunctionOnStack.java
+++ b/src/com/js/interpreter/runtime/FunctionOnStack.java
@@ -48,11 +48,11 @@ public class FunctionOnStack extends VariableContext {
 
 	@Override
 	public Object getLocalVar(String name) throws RuntimePascalException {
-		if (local_variables.containsKey(name)) {
-			return local_variables.get(name);
-		} else if (reference_variables.containsKey(name)) {
+		if (reference_variables.containsKey(name)) {
 			return reference_variables.get(name).get();
-		} else {
+		} else if (local_variables.containsKey(name)) {
+			return local_variables.get(name);
+		}else {
 			return null;
 		}
 	}
@@ -60,11 +60,11 @@ public class FunctionOnStack extends VariableContext {
 	@Override
 	@SuppressWarnings("unchecked")
 	public boolean setLocalVar(String name, Object val) {
-		if (local_variables.containsKey(name)) {
-			local_variables.put(name, val);
-		} else if (reference_variables.containsKey(name)) {
+		if (reference_variables.containsKey(name)) {
 			reference_variables.get(name).set(val);
-		} else {
+		} else if (local_variables.containsKey(name)) {
+			local_variables.put(name, val);
+		}  else {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
```
var n: integer;
procedure set(var a: integer);
begin a := 2; end;
begin
      set(n);
      writeln(n);
end.
```
//it will be print 2.